### PR TITLE
Allow urls to be used as images

### DIFF
--- a/types/image.js
+++ b/types/image.js
@@ -14,9 +14,13 @@ module.exports = class ImageArgumentType extends ArgumentType {
 			if (attachment.size > 8e+6) return 'Please provide an image under 8 MB.';
 			if (!fileTypeRe.test(attachment.name)) return 'Please only send PNG, JPG, or GIF format images.';
 			return true;
-  } else if  (fileTypeRe.test(value.toLowerCase())) {
-		 try{ await request.get(value) }catch(err){ return false; }
-		      return true;
+		} else if (fileTypeRe.test(value.toLowerCase())) {
+			try {
+				await request.get(value);
+				return true;
+			} catch(err) {
+				return false;
+			}
 		}
 		return this.client.registry.types.get('user').validate(value, msg, arg);
 	}

--- a/types/image.js
+++ b/types/image.js
@@ -14,7 +14,8 @@ module.exports = class ImageArgumentType extends ArgumentType {
 			if (attachment.size > 8e+6) return 'Please provide an image under 8 MB.';
 			if (!fileTypeRe.test(attachment.name)) return 'Please only send PNG, JPG, or GIF format images.';
 			return true;
-		} else if (fileTypeRe.test(value.toLowerCase())) {
+		}
+		if (fileTypeRe.test(value.toLowerCase())) {
 			try {
 				await request.get(value);
 				return true;

--- a/types/image.js
+++ b/types/image.js
@@ -1,6 +1,6 @@
 const { ArgumentType } = require('discord.js-commando');
 const fileTypeRe = /\.(jpe?g|png|gif)$/i;
-const request = require('node-superfetch')
+const request = require('node-superfetch');
 
 module.exports = class ImageArgumentType extends ArgumentType {
 	constructor(client) {
@@ -18,7 +18,7 @@ module.exports = class ImageArgumentType extends ArgumentType {
 			try {
 				await request.get(value);
 				return true;
-			} catch(err) {
+			} catch (err) {
 				return false;
 			}
 		}

--- a/types/image.js
+++ b/types/image.js
@@ -1,18 +1,22 @@
 const { ArgumentType } = require('discord.js-commando');
 const fileTypeRe = /\.(jpe?g|png|gif)$/i;
+const request = require('node-superfetch')
 
 module.exports = class ImageArgumentType extends ArgumentType {
 	constructor(client) {
 		super(client, 'image');
 	}
 
-	validate(value, msg, arg) {
+	async validate(value, msg, arg) {
 		const attachment = msg.attachments.first();
 		if (attachment) {
 			if (!attachment.height || !attachment.width) return false;
 			if (attachment.size > 8e+6) return 'Please provide an image under 8 MB.';
 			if (!fileTypeRe.test(attachment.name)) return 'Please only send PNG, JPG, or GIF format images.';
 			return true;
+  } else if  (fileTypeRe.test(value.toLowerCase())) {
+		 try{ await request.get(value) }catch(err){ return false; }
+		      return true;
 		}
 		return this.client.registry.types.get('user').validate(value, msg, arg);
 	}
@@ -20,6 +24,7 @@ module.exports = class ImageArgumentType extends ArgumentType {
 	async parse(value, msg, arg) {
 		const attachment = msg.attachments.first();
 		if (attachment) return attachment.url;
+		if (fileTypeRe.test(value.toLowerCase())) return value;
 		const user = await this.client.registry.types.get('user').parse(value, msg, arg);
 		return user.displayAvatarURL({ format: 'png', size: 512 });
 	}


### PR DESCRIPTION
This will allow commands that use the image argument type to accept urls that end in PNG, JPG, or GIF

**Please describe the changes this PR makes and why it should be merged**:


**Semantic versioning classification:**  
- This PR changes the code in some way
  - [ ] SEMVER patch (bug fix)
  - [1 ] SEMVER minor (commands or args added)
  - [ ] SEMVER major (commands removed or renamed, args moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to the README.
