### PR TITLE
Correction of infinite array in command

### DIFF
--- a/commands/edit-number/math.js
+++ b/commands/edit-number/math.js
@@ -28,7 +28,7 @@ module.exports = class MathCommand extends Command {
 
 	run(msg, { expression }) {
 		try {
-			const evaluated = math.evaluate(expression).toString();
+			const evaluated = math.evaluate(expression.replace(/:/g, '/')).toString();
 			return msg.reply(evaluated).catch(() => msg.reply('Invalid expression.'));
 		} catch {
 			return msg.reply('Invalid expression.');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When a person typed the command "math", putting an expression like "0:10", the bot returned an array like this: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ], but if the person types for example "0: 9999999999", can create an infinite array, and the bot starts to crash or even crash, I fixed it, just by replacing the character ":" to "/"


**Semantic versioning classification:**  
- This PR changes the code in some way
  - [ X ] SEMVER patch (bug fix)
  - [ ] SEMVER minor (commands or args added)
  - [ ] SEMVER major (commands removed or renamed, args moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to the README.
