### PR TITLE
ci: update lint job steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node v14
+      - name: Install Node v15
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 15
 
       - name: Install ESLint v7
         run: npm install -g eslint@7
         
       - name: Install ESLint Configs and Plugins
-        run: npm install eslint-config-amber eslint-plugin-json
+        run: npm install --only=dev
 
       - name: Run ESLint
         run: npm test


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR switches the Github Action to use Node 15 per the package.json and uses `npm install --only=dev` for future-proofing

**Semantic versioning classification:**  
- This PR changes the code in some way
  - [ ] SEMVER patch (bug fix)
  - [ ] SEMVER minor (commands or args added)
  - [ ] SEMVER major (commands removed or renamed, args moved or removed)
- [x] This PR **only** includes non-code changes, like changes to the README.
